### PR TITLE
Revert "IG-13167 pass kube_feature_gates"

### DIFF
--- a/run.py
+++ b/run.py
@@ -38,7 +38,7 @@ def run(do_reset, servers_supp_ips):
     _run_ansible(playbooks_dir, 'cluster', become=True, kubectl_localhost=True,
                  kubeconfig_localhost=True, deploy_container_engine=False, skip_downloads=True,
                  preinstall_selinux_state='disabled', kube_proxy_mode='iptables',
-                 supplementary_addresses_in_ssl_keys=servers_supp_ips, kube_feature_gates=["KubeletPodResources=true"])
+                 supplementary_addresses_in_ssl_keys=servers_supp_ips)
     _run_ansible(playbooks_dir, 'clients')
 
 


### PR DESCRIPTION
Reverts iguazio/kubespray#19

this feature in alpha in kube 13.5
starting from 1.15 it's in beta 
introduce bug  "kubelet start failed" - fixed in 1.15 and upper

https://github.com/kubernetes/kubernetes/pull/77274#issuecomment-497375090